### PR TITLE
Fix Div being dropped due to replaceNegative

### DIFF
--- a/convert/src/file.ts
+++ b/convert/src/file.ts
@@ -34,7 +34,7 @@ base.close = "\n}\n";
 
 const replaceNegative = (config: Config, key: string, value: string): string => {
   if (value.startsWith("-")) { return `neg-${key}`; }
-  return value.replace(`${config.separator || ":"}-`, '-neg-');
+  return key.replace(`${config.separator || ":"}-`, '-neg-');
 };
 
 // This works like toCamelCase, with a "minus" special case:


### PR DESCRIPTION
I think replaceNegative does the wrong thing because it calls replace on `value` rather than `key`.

This means that any changes made to `key` are overriden (i.e. replacing `"/"` with `"-div-"`), which causes issues.

As a concrete example, both `xl:w-12` and `xl:w-1/2` have the same key (`xlW12`) with the old code, but they don't with the new code.